### PR TITLE
Fix(HyperlaneIsmFactory): Prototype-polluting assignment

### DIFF
--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -82,7 +82,7 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
   // The shape of this object is `ChainMap<Address | ChainMap<Address>`,
   // although `any` is use here because that type breaks a lot of signatures.
   // TODO: fix this in the next refactoring
-  public deployedIsms: ChainMap<any> = {};
+  public deployedIsms: ChainMap<any> = Object.create(null);
   protected readonly deployer: IsmDeployer;
 
   constructor(
@@ -117,6 +117,9 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
     existingIsmAddress?: Address;
   }): Promise<DeployedIsm> {
     const { destination, config, origin, mailbox, existingIsmAddress } = params;
+    if (typeof destination !== 'string' || destination === '__proto__' || destination === 'constructor' || destination === 'prototype') {
+      throw new Error(`Invalid destination: ${destination}`);
+    }
     if (typeof config === 'string') {
       // @ts-ignore
       return IInterchainSecurityModule__factory.connect(


### PR DESCRIPTION
https://github.com/DexlynLabs/bridge-repo/blob/6a772c126e0879928021156ca91b89ac4f1bfcae/typescript/sdk/src/ism/HyperlaneIsmFactory.ts#L224-L224

Fix the issue need to prevent prototype pollution by ensuring that untrusted keys like `destination` cannot modify `Object.prototype`. The best approach is to use a prototype-less object for `this.deployedIsms`. This can be achieved by initializing `this.deployedIsms` with `Object.create(null)` instead of `{}`. A prototype-less object does not inherit from `Object.prototype`, making it immune to prototype pollution.

Additionally, we should validate the `destination` parameter to ensure it conforms to expected formats (e.g., a string matching a predefined set of chain names).

#### References
[Object.prototype.proto](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)
[Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)

---
